### PR TITLE
feat: add version flag and self update command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,9 @@ jobs:
 
       - name: cargo build
         run: |
-          cargo build --release
+          VERSION="${GITHUB_REF_NAME#v}"
+          SHORT_SHA="${GITHUB_SHA::7}"
+          KUORI_SEMVER="${VERSION}" KUORI_GIT_SHA="${SHORT_SHA}" cargo build --release
           mv target/release/kuori kuori-x86_64-unknown-linux-gnu
         
       - name: Create GitHub Release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ rand = "0.8.5"
 clap = { version = "4.5.17", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+ureq = { version = "=2.9.7", default-features = true }
+url = "=2.4.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod ssh;
 mod ssh_config;
+mod update;
 mod util;
 
 use anyhow::Context;
@@ -15,7 +16,11 @@ use std::{
 
 // コマンドライン引数
 #[derive(Parser, Debug)]
+#[command(disable_version_flag = true)]
 struct CliArgs {
+    #[arg(short = 'v', long = "version", action = clap::ArgAction::SetTrue)]
+    version: bool,
+
     #[command(subcommand)]
     command: Option<CliCommand>,
 
@@ -30,6 +35,7 @@ struct CliArgs {
 enum CliCommand {
     Run(RunArgs),
     Validate(ValidateArgs),
+    Update,
 }
 
 #[derive(Args, Debug)]
@@ -101,11 +107,25 @@ async fn run_tasks(config: Config, task_names: Option<String>) -> anyhow::Result
     Ok(())
 }
 
+fn version_string() -> String {
+    let semver = option_env!("KUORI_SEMVER").unwrap_or("unknown");
+    let sha = option_env!("KUORI_GIT_SHA").unwrap_or("unknown");
+    format!("{semver}+{sha}")
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = CliArgs::parse();
 
+    if args.version {
+        println!("{}", version_string());
+        return Ok(());
+    }
+
     match args.command {
+        Some(CliCommand::Update) => {
+            update::run()?;
+        }
         Some(CliCommand::Validate(validate_args)) => {
             load_config(&validate_args.config)?;
         }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,8 +1,10 @@
 use anyhow::{bail, Context};
 use std::{
     fs,
+    fs::File,
+    io,
     path::{Path, PathBuf},
-    process::{self, Command},
+    process,
 };
 
 const REPOSITORY: &str = "wim-web/kuori";
@@ -49,28 +51,30 @@ fn staging_binary_path(current_exe: &Path) -> anyhow::Result<PathBuf> {
 }
 
 fn download_latest_release(asset_name: &str, output_path: &Path) -> anyhow::Result<()> {
-    let output = Command::new("gh")
-        .args([
-            "release",
-            "download",
-            "--repo",
-            REPOSITORY,
-            "--latest",
-            "--pattern",
-            asset_name,
-            "--clobber",
-        ])
-        .arg("--output")
-        .arg(output_path)
-        .output()
-        .context("`gh` コマンドの実行に失敗しました。GitHub CLI をインストールしてください")?;
+    let url = format!(
+        "https://github.com/{}/releases/latest/download/{}",
+        REPOSITORY, asset_name
+    );
+    let response = ureq::get(&url)
+        .set("User-Agent", "kuori-self-update")
+        .call()
+        .map_err(|error| anyhow::anyhow!("最新リリースの取得に失敗しました: {}", error))?;
+    let status_code = response.status();
 
-    if output.status.success() {
-        return Ok(());
+    let mut file = File::create(output_path).with_context(|| {
+        format!(
+            "更新用ファイルの作成に失敗しました: {}",
+            output_path.display()
+        )
+    })?;
+    let mut reader = response.into_reader();
+    io::copy(&mut reader, &mut file).context("更新バイナリの保存に失敗しました")?;
+
+    if !(200..300).contains(&status_code) {
+        bail!("最新リリースの取得に失敗しました: HTTP {}", status_code);
     }
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    bail!("最新リリースの取得に失敗しました: {}", stderr.trim());
+    Ok(())
 }
 
 fn set_executable_permission(path: &Path) -> anyhow::Result<()> {

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,87 @@
+use anyhow::{bail, Context};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{self, Command},
+};
+
+const REPOSITORY: &str = "wim-web/kuori";
+const LINUX_X86_64_ASSET_NAME: &str = "kuori-x86_64-unknown-linux-gnu";
+
+pub fn run() -> anyhow::Result<()> {
+    let asset_name = release_asset_name()?;
+    let current_exe =
+        std::env::current_exe().context("現在の実行ファイルパスの取得に失敗しました")?;
+    let staging_path = staging_binary_path(&current_exe)?;
+
+    download_latest_release(asset_name, &staging_path)?;
+    set_executable_permission(&staging_path)?;
+
+    fs::rename(&staging_path, &current_exe).with_context(|| {
+        format!(
+            "バイナリの置換に失敗しました: {} -> {}",
+            staging_path.display(),
+            current_exe.display()
+        )
+    })?;
+
+    println!("kuori を最新バージョンに更新しました。");
+    Ok(())
+}
+
+fn release_asset_name() -> anyhow::Result<&'static str> {
+    if cfg!(all(
+        target_os = "linux",
+        target_arch = "x86_64",
+        target_env = "gnu"
+    )) {
+        return Ok(LINUX_X86_64_ASSET_NAME);
+    }
+
+    bail!("この環境向けの更新は未対応です（linux/x86_64/gnu のみ対応）");
+}
+
+fn staging_binary_path(current_exe: &Path) -> anyhow::Result<PathBuf> {
+    let parent = current_exe
+        .parent()
+        .context("実行ファイルディレクトリを特定できませんでした")?;
+    Ok(parent.join(format!(".kuori-update-{}", process::id())))
+}
+
+fn download_latest_release(asset_name: &str, output_path: &Path) -> anyhow::Result<()> {
+    let output = Command::new("gh")
+        .args([
+            "release",
+            "download",
+            "--repo",
+            REPOSITORY,
+            "--latest",
+            "--pattern",
+            asset_name,
+            "--clobber",
+        ])
+        .arg("--output")
+        .arg(output_path)
+        .output()
+        .context("`gh` コマンドの実行に失敗しました。GitHub CLI をインストールしてください")?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    bail!("最新リリースの取得に失敗しました: {}", stderr.trim());
+}
+
+fn set_executable_permission(path: &Path) -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = fs::metadata(path)?.permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## 背景 / 目的
- kuori に `--version` / `-v` と自己更新コマンドがなかったため追加。

## 変更内容
- `-v` / `--version` を追加
  - 表示は `KUORI_SEMVER` と `KUORI_GIT_SHA` を連結 (`<semver>+<sha>`)
  - 未注入時は `unknown+unknown`
- `kuori update` を追加
  - GitHub Releases (`wim-web/kuori`) の最新資産 `kuori-x86_64-unknown-linux-gnu` を取得して実行中バイナリを置換
  - 対応環境は `linux/x86_64/gnu`
- Release workflow を更新
  - `KUORI_SEMVER` と `KUORI_GIT_SHA` を build 時に注入

## 動作確認
- `cargo fmt`
- `cargo check`
- `cargo run -- --help`
- `cargo run -- -v` -> `unknown+unknown`
- `KUORI_SEMVER=1.2.3 KUORI_GIT_SHA=deadbee cargo run -- -v` -> `1.2.3+deadbee`
- `cargo run -- update --help`

## 影響範囲 / リスク
- 既存コマンド (`run`, `validate`, 後方互換の `--config` 実行) は維持。
- `update` は現時点で Linux x86_64 GNU のみ対応。
