### PR TITLE
fix: inject version metadata in macOS self-update builds

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -4,13 +4,31 @@ use std::{
     fs::File,
     io,
     path::{Path, PathBuf},
-    process,
+    process::{self, Command},
 };
 
 const REPOSITORY: &str = "wim-web/kuori";
+const REPOSITORY_GIT_URL: &str = "https://github.com/wim-web/kuori.git";
+const PACKAGE_NAME: &str = "kuori";
 const LINUX_X86_64_ASSET_NAME: &str = "kuori-x86_64-unknown-linux-gnu";
 
 pub fn run() -> anyhow::Result<()> {
+    if cfg!(target_os = "macos") {
+        return run_update_via_cargo_install();
+    }
+
+    if cfg!(all(
+        target_os = "linux",
+        target_arch = "x86_64",
+        target_env = "gnu"
+    )) {
+        return run_update_via_release_asset();
+    }
+
+    bail!("この環境向けの更新は未対応です");
+}
+
+fn run_update_via_release_asset() -> anyhow::Result<()> {
     let asset_name = release_asset_name()?;
     let current_exe =
         std::env::current_exe().context("現在の実行ファイルパスの取得に失敗しました")?;
@@ -31,16 +49,73 @@ pub fn run() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn release_asset_name() -> anyhow::Result<&'static str> {
-    if cfg!(all(
-        target_os = "linux",
-        target_arch = "x86_64",
-        target_env = "gnu"
-    )) {
-        return Ok(LINUX_X86_64_ASSET_NAME);
+fn run_update_via_cargo_install() -> anyhow::Result<()> {
+    let latest_tag = latest_tag_from_remote()?;
+    let output = Command::new("cargo")
+        .args([
+            "install",
+            "--git",
+            REPOSITORY_GIT_URL,
+            "--tag",
+            &latest_tag,
+            "--force",
+            PACKAGE_NAME,
+        ])
+        .output()
+        .context("`cargo` コマンドの実行に失敗しました")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("`cargo install` に失敗しました: {}", stderr.trim());
     }
 
-    bail!("この環境向けの更新は未対応です（linux/x86_64/gnu のみ対応）");
+    println!("kuori を最新バージョンに更新しました。tag: {}", latest_tag);
+    Ok(())
+}
+
+fn latest_tag_from_remote() -> anyhow::Result<String> {
+    let output = Command::new("git")
+        .args(["ls-remote", "--tags", "--refs", REPOSITORY_GIT_URL])
+        .output()
+        .context("`git` コマンドの実行に失敗しました")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("最新タグ取得に失敗しました: {}", stderr.trim());
+    }
+
+    let stdout = String::from_utf8(output.stdout).context("タグ一覧のデコードに失敗しました")?;
+    pick_latest_semver_tag(&stdout).context("semver形式のタグが見つかりませんでした")
+}
+
+fn pick_latest_semver_tag(input: &str) -> Option<String> {
+    input
+        .lines()
+        .filter_map(parse_semver_tag_from_ls_remote_line)
+        .max_by(|(_, a), (_, b)| a.cmp(b))
+        .map(|(tag, _)| tag)
+}
+
+fn parse_semver_tag_from_ls_remote_line(line: &str) -> Option<(String, (u64, u64, u64))> {
+    let (_, ref_name) = line.split_once('\t')?;
+    let tag = ref_name.strip_prefix("refs/tags/")?;
+    let version = parse_semver(tag)?;
+    Some((tag.to_string(), version))
+}
+
+fn parse_semver(tag: &str) -> Option<(u64, u64, u64)> {
+    let version = tag.strip_prefix('v')?;
+    let mut parts = version.split('.');
+
+    let major = parts.next()?.parse::<u64>().ok()?;
+    let minor = parts.next()?.parse::<u64>().ok()?;
+    let patch = parts.next()?.parse::<u64>().ok()?;
+
+    if parts.next().is_some() {
+        return None;
+    }
+
+    Some((major, minor, patch))
 }
 
 fn staging_binary_path(current_exe: &Path) -> anyhow::Result<PathBuf> {
@@ -75,6 +150,46 @@ fn download_latest_release(asset_name: &str, output_path: &Path) -> anyhow::Resu
     }
 
     Ok(())
+}
+
+fn release_asset_name() -> anyhow::Result<&'static str> {
+    if cfg!(all(
+        target_os = "linux",
+        target_arch = "x86_64",
+        target_env = "gnu"
+    )) {
+        return Ok(LINUX_X86_64_ASSET_NAME);
+    }
+
+    bail!("この環境向けの更新は未対応です（linux/x86_64/gnu のみ対応）");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pick_latest_semver_tag;
+
+    #[test]
+    fn picks_latest_tag() {
+        let input = "\
+aaaaaaaa\trefs/tags/v1.2.9
+bbbbbbbb\trefs/tags/v1.10.0
+cccccccc\trefs/tags/v1.3.0
+";
+        let latest = pick_latest_semver_tag(input);
+        assert_eq!(latest.as_deref(), Some("v1.10.0"));
+    }
+
+    #[test]
+    fn ignores_non_semver_tags() {
+        let input = "\
+aaaaaaaa\trefs/tags/latest
+bbbbbbbb\trefs/tags/v1.2
+cccccccc\trefs/tags/v2.0.0-rc.1
+dddddddd\trefs/tags/v2.0.0
+";
+        let latest = pick_latest_semver_tag(input);
+        assert_eq!(latest.as_deref(), Some("v2.0.0"));
+    }
 }
 
 fn set_executable_permission(path: &Path) -> anyhow::Result<()> {

--- a/src/update.rs
+++ b/src/update.rs
@@ -12,6 +12,12 @@ const REPOSITORY_GIT_URL: &str = "https://github.com/wim-web/kuori.git";
 const PACKAGE_NAME: &str = "kuori";
 const LINUX_X86_64_ASSET_NAME: &str = "kuori-x86_64-unknown-linux-gnu";
 
+struct ReleaseTag {
+    tag: String,
+    semver: String,
+    sha: String,
+}
+
 pub fn run() -> anyhow::Result<()> {
     if cfg!(target_os = "macos") {
         return run_update_via_cargo_install();
@@ -50,17 +56,21 @@ fn run_update_via_release_asset() -> anyhow::Result<()> {
 }
 
 fn run_update_via_cargo_install() -> anyhow::Result<()> {
-    let latest_tag = latest_tag_from_remote()?;
+    let latest = latest_tag_from_remote()?;
+    let short_sha: String = latest.sha.chars().take(7).collect();
+
     let output = Command::new("cargo")
         .args([
             "install",
             "--git",
             REPOSITORY_GIT_URL,
             "--tag",
-            &latest_tag,
+            &latest.tag,
             "--force",
             PACKAGE_NAME,
         ])
+        .env("KUORI_SEMVER", &latest.semver)
+        .env("KUORI_GIT_SHA", &short_sha)
         .output()
         .context("`cargo` コマンドの実行に失敗しました")?;
 
@@ -69,11 +79,14 @@ fn run_update_via_cargo_install() -> anyhow::Result<()> {
         bail!("`cargo install` に失敗しました: {}", stderr.trim());
     }
 
-    println!("kuori を最新バージョンに更新しました。tag: {}", latest_tag);
+    println!(
+        "kuori を最新バージョンに更新しました。tag: {}, version: {}+{}",
+        latest.tag, latest.semver, short_sha
+    );
     Ok(())
 }
 
-fn latest_tag_from_remote() -> anyhow::Result<String> {
+fn latest_tag_from_remote() -> anyhow::Result<ReleaseTag> {
     let output = Command::new("git")
         .args(["ls-remote", "--tags", "--refs", REPOSITORY_GIT_URL])
         .output()
@@ -85,7 +98,13 @@ fn latest_tag_from_remote() -> anyhow::Result<String> {
     }
 
     let stdout = String::from_utf8(output.stdout).context("タグ一覧のデコードに失敗しました")?;
-    pick_latest_semver_tag(&stdout).context("semver形式のタグが見つかりませんでした")
+    let tag = pick_latest_semver_tag(&stdout).context("semver形式のタグが見つかりませんでした")?;
+    let semver = semver_without_prefix(&tag)
+        .context("最新タグのsemver解析に失敗しました")?
+        .to_string();
+    let sha = resolve_tag_sha(&tag)?;
+
+    Ok(ReleaseTag { tag, semver, sha })
 }
 
 fn pick_latest_semver_tag(input: &str) -> Option<String> {
@@ -116,6 +135,49 @@ fn parse_semver(tag: &str) -> Option<(u64, u64, u64)> {
     }
 
     Some((major, minor, patch))
+}
+
+fn semver_without_prefix(tag: &str) -> Option<&str> {
+    parse_semver(tag)?;
+    tag.strip_prefix('v')
+}
+
+fn resolve_tag_sha(tag: &str) -> anyhow::Result<String> {
+    let peeled_ref = format!("refs/tags/{tag}^{{}}");
+    if let Some(sha) = ls_remote_sha_for_ref(&peeled_ref)? {
+        return Ok(sha);
+    }
+
+    let direct_ref = format!("refs/tags/{tag}");
+    if let Some(sha) = ls_remote_sha_for_ref(&direct_ref)? {
+        return Ok(sha);
+    }
+
+    bail!("タグ {} のSHAが取得できませんでした", tag);
+}
+
+fn ls_remote_sha_for_ref(reference: &str) -> anyhow::Result<Option<String>> {
+    let output = Command::new("git")
+        .args(["ls-remote", REPOSITORY_GIT_URL, reference])
+        .output()
+        .context("`git` コマンドの実行に失敗しました")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("タグSHA取得に失敗しました: {}", stderr.trim());
+    }
+
+    let stdout = String::from_utf8(output.stdout).context("タグSHAのデコードに失敗しました")?;
+    let line = stdout.lines().next();
+    Ok(line.and_then(parse_sha_from_ls_remote_line))
+}
+
+fn parse_sha_from_ls_remote_line(line: &str) -> Option<String> {
+    let (sha, _) = line.split_once('\t')?;
+    if sha.is_empty() {
+        return None;
+    }
+    Some(sha.to_string())
 }
 
 fn staging_binary_path(current_exe: &Path) -> anyhow::Result<PathBuf> {
@@ -166,7 +228,7 @@ fn release_asset_name() -> anyhow::Result<&'static str> {
 
 #[cfg(test)]
 mod tests {
-    use super::pick_latest_semver_tag;
+    use super::{parse_sha_from_ls_remote_line, pick_latest_semver_tag, semver_without_prefix};
 
     #[test]
     fn picks_latest_tag() {
@@ -189,6 +251,19 @@ dddddddd\trefs/tags/v2.0.0
 ";
         let latest = pick_latest_semver_tag(input);
         assert_eq!(latest.as_deref(), Some("v2.0.0"));
+    }
+
+    #[test]
+    fn strips_v_prefix_from_semver_tag() {
+        assert_eq!(semver_without_prefix("v1.2.3"), Some("1.2.3"));
+        assert_eq!(semver_without_prefix("latest"), None);
+    }
+
+    #[test]
+    fn parses_sha_from_ls_remote_line() {
+        let line = "0123456789abcdef\trefs/tags/v1.0.0";
+        let sha = parse_sha_from_ls_remote_line(line);
+        assert_eq!(sha.as_deref(), Some("0123456789abcdef"));
     }
 }
 


### PR DESCRIPTION
## 背景
- `kuori update` 実行後も `kuori -v` が `unknown+unknown` になる問題がありました。
- 原因は macOS の更新フロー（`cargo install --git --tag`）で、ビルド時バージョン情報を環境変数注入していなかったことです。

## 変更内容
- macOS の `update` フローを以下に変更
  - 最新タグを取得（semverタグのみ対象）
  - 取得タグのSHAを解決（annotated tag / lightweight tag 両対応）
  - `cargo install --git ... --tag ...` 実行時に以下を注入
    - `KUORI_SEMVER`（例: `1.0.0`）
    - `KUORI_GIT_SHA`（例: `b84400d`）
- タグ/sha解決ロジックのユニットテストを追加

## 確認
- `cargo check`
- `cargo test update::tests -- --nocapture`

## 影響範囲
- 変更対象は `src/update.rs` のみ。
- Linux向けの release asset 更新フローは維持。
