### PR TITLE
docs: READMEとCLI helpの説明を強化

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,126 @@
-## config
+# kuori
 
-### validate
+`kuori` は、JSON で定義したタスクを使って、SSH 経由でリモートホストにスクリプトを配布・実行する CLI ツールです。  
+「同じ運用コマンドを複数ホストへ安全に順次実行したい」用途を想定しています。
 
-```
+## 何をするツールか
+
+- 設定ファイル（JSON）からタスク一覧を読み込む
+- `~/.ssh/config` を使って対象ホストへ接続する
+- ローカルの `script_path` をリモートへ転送して実行する
+- 実行時に環境変数 (`environments`) を付与できる
+- `sudo` 指定があれば `sudo bash ...` で実行する
+- 実行後、転送した一時スクリプトを削除する
+
+## 事前準備
+
+- ローカルに `kuori` をインストール済みであること
+- `~/.ssh/config` に `host` で参照するエントリがあること
+  - 少なくとも `HostName` / `User` / `IdentityFile` が解決できること
+- 各タスクの `script_path` がローカルで存在すること
+- 各タスクの `working_dir` がリモート上で存在し、書き込み可能であること
+
+## クイックスタート
+
+```bash
+# 1) 設定ファイルを検証
 kuori validate --config config.example.json
+
+# 2) 全タスク実行
+kuori run --config config.example.json
+
+# 3) 一部タスクのみ実行（name をカンマ区切り）
+kuori run --config config.example.json --task-names deploy-api,restart-worker
 ```
 
-`kuori` 実行時に、以下を自動で検証します。
+後方互換として、サブコマンドなしでも `run` 相当で実行できます。
+
+```bash
+kuori --config config.example.json --task-names deploy-api
+```
+
+## 設定ファイル（JSON）
+
+`config.example.json`:
+
+```json
+{
+  "tasks": [
+    {
+      "name": "deploy-api",
+      "host": "api-server",
+      "script_path": "./scripts/deploy-api.sh",
+      "working_dir": "/tmp",
+      "sudo": false,
+      "environments": {
+        "RUST_LOG": "info",
+        "APP_ENV": "production"
+      }
+    }
+  ]
+}
+```
+
+### フィールド定義
+
+| フィールド | 型 | 必須 | 説明 |
+| --- | --- | --- | --- |
+| `tasks` | array | はい | 実行タスクの配列（1件以上必須） |
+| `tasks[].name` | string | はい | タスク識別名。`task_names` 指定時に使う。重複不可 |
+| `tasks[].host` | string | はい | `~/.ssh/config` の `Host` 名 |
+| `tasks[].script_path` | string | はい | ローカルの実行スクリプトパス |
+| `tasks[].working_dir` | string | はい | リモート側の作業ディレクトリ |
+| `tasks[].sudo` | bool | はい | `true` なら `sudo bash` で実行 |
+| `tasks[].environments` | object | はい | 追加環境変数（`KEY: VALUE`） |
+
+### バリデーション内容
+
+`kuori validate`（および `kuori run` の内部）で以下を検証します。
 
 - `tasks` が空でないこと
 - 各 `task` の `name` / `host` / `script_path` / `working_dir` が空文字でないこと
 - `task.name` が重複していないこと
 
-### run
+## コマンド一覧
 
-```
-kuori run --config config.json
-```
+### `run`
 
-`example` を使う場合:
+設定ファイルを読み込み、タスクを順番に実行します。
 
 ```bash
-kuori validate --config config.example.json
-kuori run --config config.example.json
+kuori run --config config.json
+kuori run --config config.json --task-names deploy-api,restart-worker
 ```
+
+### `validate`
+
+設定ファイルを検証のみ行います（実行なし）。
+
+```bash
+kuori validate --config config.json
+```
+
+### `update`
+
+`kuori` 自身を最新へ更新します。
+
+- macOS: `cargo install --git` で更新
+- Linux (`x86_64-unknown-linux-gnu`): GitHub Releases の最新バイナリで更新
+
+```bash
+kuori update
+```
+
+### `--version`
+
+バージョン情報（`semver+sha`）を表示します。
+
+```bash
+kuori --version
+```
+
+## 補足
+
+- `--task-names` は完全一致です（部分一致しません）
+- タスクは並列ではなく順次実行です
+- 標準出力はリモート実行結果をそのままストリーム表示します

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,39 +16,102 @@ use std::{
 
 // コマンドライン引数
 #[derive(Parser, Debug)]
-#[command(disable_version_flag = true)]
+#[command(
+    name = "kuori",
+    disable_version_flag = true,
+    about = "SSH経由で複数ホストへスクリプトを配布・実行するCLIタスクランナー",
+    long_about = "kuori は JSON で定義したタスクを順番に実行する CLI です。\n\
+各タスクは `host` と `script_path` を持ち、指定したホストへスクリプトを転送して実行します。\n\
+`run` 実行時には設定ファイルのバリデーションも自動で行われます。",
+    after_help = "例:\n\
+  kuori validate --config config.json\n\
+  kuori run --config config.json\n\
+  kuori run --config config.json --task-names deploy-api,restart-worker\n\
+  kuori --config config.json  # 後方互換: `run` として実行\n"
+)]
 struct CliArgs {
-    #[arg(short = 'v', long = "version", action = clap::ArgAction::SetTrue)]
+    #[arg(
+        short = 'v',
+        long = "version",
+        action = clap::ArgAction::SetTrue,
+        help = "バージョン情報を表示して終了"
+    )]
     version: bool,
 
     #[command(subcommand)]
     command: Option<CliCommand>,
 
     // 後方互換: `kuori --config ...` は `run` として扱う
-    #[arg(short, long)]
+    #[arg(
+        short,
+        long,
+        value_name = "FILE",
+        help = "設定ファイル(JSON)のパス（サブコマンド未指定時のみ有効）",
+        long_help = "設定ファイル(JSON)のパス。\n\
+サブコマンド未指定時は `run --config <FILE>` と同じ動作になります。"
+    )]
     config: Option<PathBuf>, // --config で設定ファイルを指定
-    #[arg(long)]
+    #[arg(
+        long,
+        value_name = "NAMES",
+        help = "実行対象 task.name をカンマ区切りで指定（サブコマンド未指定時のみ有効）",
+        long_help = "実行対象の task.name をカンマ区切りで指定します。\n\
+例: --task-names deploy-api,restart-worker\n\
+サブコマンド未指定時は `run --task-names <NAMES>` と同じ動作になります。"
+    )]
     task_names: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]
 enum CliCommand {
+    #[command(
+        about = "設定ファイルに定義されたタスクを実行",
+        long_about = "設定ファイルを読み込み、バリデーションに成功したタスクを順番に実行します。\n\
+`--task-names` を指定すると対象タスクを絞り込めます。"
+    )]
     Run(RunArgs),
+    #[command(
+        about = "設定ファイルの妥当性のみ検証",
+        long_about = "設定ファイル(JSON)の形式と必須項目を検証します。\n\
+実行は行わず、問題がある場合のみエラーで終了します。"
+    )]
     Validate(ValidateArgs),
+    #[command(
+        about = "kuori を最新バージョンへ更新",
+        long_about = "実行環境に応じて kuori を自己更新します。\n\
+macOS: `cargo install --git` を利用\n\
+linux/x86_64/gnu: GitHub Releases の最新バイナリを利用"
+    )]
     Update,
 }
 
 #[derive(Args, Debug)]
 struct RunArgs {
-    #[arg(short, long)]
+    #[arg(
+        short,
+        long,
+        value_name = "FILE",
+        help = "設定ファイル(JSON)のパス"
+    )]
     config: PathBuf,
-    #[arg(long)]
+    #[arg(
+        long,
+        value_name = "NAMES",
+        help = "実行対象 task.name をカンマ区切りで指定",
+        long_help = "実行対象の task.name をカンマ区切りで指定します。\n\
+例: --task-names deploy-api,restart-worker"
+    )]
     task_names: Option<String>,
 }
 
 #[derive(Args, Debug)]
 struct ValidateArgs {
-    #[arg(short, long)]
+    #[arg(
+        short,
+        long,
+        value_name = "FILE",
+        help = "検証対象の設定ファイル(JSON)のパス"
+    )]
     config: PathBuf,
 }
 


### PR DESCRIPTION
## 背景 / 目的
`README.md` と `kuori --help` の情報量が少なく、初見ユーザーが「何をするツールか」「どう使えばよいか」を把握しづらい状態でした。  
そのため、用途説明と実行例を中心にドキュメントとCLIヘルプを強化しました。

## 変更内容
- `README.md` を再構成
  - ツールの目的
  - 事前準備
  - クイックスタート
  - 設定ファイル項目の定義表
  - コマンド一覧（`run` / `validate` / `update` / `--version`）
  - 補足（`task-names` の一致条件、逐次実行など）
- `src/main.rs` の `clap` 定義を拡充
  - トップレベル `about` / `long_about` / `after_help`
  - サブコマンドごとの `about` / `long_about`
  - `--config` / `--task-names` / `--version` / `validate --config` の help 文
  - `value_name` を追加してヘルプの可読性を向上

## 動作確認
- `cargo test`
  - 結果: 8 passed / 0 failed
- `cargo run -- --help`
  - トップレベル説明・各コマンド説明・使用例が表示されることを確認

## 影響範囲 / リスク / ロールバック
- 影響範囲: `README.md` と CLIヘルプ表示文言のみ（実行ロジック変更なし）
- リスク: 低（文言変更中心）
- ロールバック: 本PRのコミットをrevertすれば復元可能

## 関連Issue
- なし
