### PR TITLE
feat: add dry-run and per-task timeout/retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ kuori --config config.example.json --task-names deploy-api
 - `tasks` が空でないこと
 - 各 `task` の `name` / `host` / `script_path` / `working_dir` が空文字でないこと
 - `task.name` が重複していないこと
+- `task.timeout_sec` を指定した場合に 1 以上であること
 
 ## コマンド一覧
 
@@ -90,6 +91,22 @@ kuori --config config.example.json --task-names deploy-api
 ```bash
 kuori run --config config.json
 kuori run --config config.json --task-names deploy-api,restart-worker
+kuori run --config config.json --dry-run
+```
+
+`--dry-run` を付けると、SSH接続せずに実行予定タスクを表示します。
+
+`timeout_sec`（秒）と `retry`（再試行回数）を `task` ごとに指定できます。
+
+- `timeout_sec`: 1回の実行で許可する最大秒数（未指定で無制限）
+- `retry`: 失敗時の再試行回数（`0` で再試行なし）
+
+`example` を使う場合:
+
+```bash
+kuori validate --config config.example.json
+kuori run --config config.example.json
+kuori run --config config.example.json --dry-run
 ```
 
 ### `validate`

--- a/config.example.json
+++ b/config.example.json
@@ -6,6 +6,8 @@
       "script_path": "./scripts/deploy-api.sh",
       "working_dir": "/tmp",
       "sudo": false,
+      "timeout_sec": 600,
+      "retry": 1,
       "environments": {
         "RUST_LOG": "info",
         "APP_ENV": "production"
@@ -17,6 +19,8 @@
       "script_path": "./scripts/restart-worker.sh",
       "working_dir": "/tmp",
       "sudo": true,
+      "timeout_sec": 120,
+      "retry": 2,
       "environments": {}
     }
   ]

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,8 @@ pub struct Task {
     pub working_dir: String,
     pub sudo: bool,
     pub environments: HashMap<String, String>,
+    pub timeout_sec: Option<u64>,
+    pub retry: Option<u32>,
 }
 
 // 設定の定義
@@ -32,6 +34,7 @@ impl Config {
             validate_non_empty(&task.host, "host", idx)?;
             validate_non_empty(&task.script_path, "script_path", idx)?;
             validate_non_empty(&task.working_dir, "working_dir", idx)?;
+            validate_timeout_sec(task.timeout_sec, idx)?;
 
             if !seen_names.insert(task.name.as_str()) {
                 bail!("tasks[{idx}].name is duplicated: {}", task.name);
@@ -50,6 +53,14 @@ fn validate_non_empty(value: &str, field_name: &str, task_index: usize) -> anyho
     Ok(())
 }
 
+fn validate_timeout_sec(timeout_sec: Option<u64>, task_index: usize) -> anyhow::Result<()> {
+    if timeout_sec == Some(0) {
+        bail!("tasks[{task_index}].timeout_sec must be greater than 0");
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Config, Task};
@@ -63,6 +74,8 @@ mod tests {
             working_dir: "/tmp".to_string(),
             sudo: false,
             environments: HashMap::new(),
+            timeout_sec: None,
+            retry: None,
         }
     }
 
@@ -96,5 +109,15 @@ mod tests {
             tasks: vec![task("deploy"), task("cleanup")],
         };
         assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_fails_when_timeout_sec_is_zero() {
+        let mut timeout_zero_task = task("deploy");
+        timeout_zero_task.timeout_sec = Some(0);
+        let config = Config {
+            tasks: vec![timeout_zero_task],
+        };
+        assert!(config.validate().is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,8 @@ struct CliArgs {
 サブコマンド未指定時は `run --task-names <NAMES>` と同じ動作になります。"
     )]
     task_names: Option<String>,
+    #[arg(long)]
+    dry_run: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -102,6 +104,8 @@ struct RunArgs {
 例: --task-names deploy-api,restart-worker"
     )]
     task_names: Option<String>,
+    #[arg(long)]
+    dry_run: bool,
 }
 
 #[derive(Args, Debug)]
@@ -137,34 +141,96 @@ fn parse_task_names(task_names: Option<String>) -> Option<Vec<String>> {
     })
 }
 
-async fn run_tasks(config: Config, task_names: Option<String>) -> anyhow::Result<()> {
-    let ssh_config = read_ssh_config(SshConfigPath::default())?;
+fn format_env_keys(task: &config::Task) -> String {
+    if task.environments.is_empty() {
+        return "(none)".to_string();
+    }
 
-    let mut session_manager = SessionManager::new();
-    let client = KuoriClient::new(ssh_config);
+    let mut keys = task.environments.keys().cloned().collect::<Vec<String>>();
+    keys.sort();
+    keys.join(",")
+}
+
+async fn run_tasks(
+    config: Config,
+    task_names: Option<String>,
+    dry_run: bool,
+) -> anyhow::Result<()> {
     let parsed_task_names = parse_task_names(task_names);
-
     let should_execute = |task_name: &str| match &parsed_task_names {
         Some(tasks) => tasks.iter().any(|name| name == task_name),
         None => true,
     };
+    let tasks = config
+        .tasks
+        .into_iter()
+        .filter(|task| should_execute(&task.name))
+        .collect::<Vec<_>>();
 
-    for task in config.tasks {
-        if !should_execute(&task.name) {
-            continue;
+    if dry_run {
+        println!("dry-run: {} task(s) selected", tasks.len());
+        for (idx, task) in tasks.iter().enumerate() {
+            let timeout = task
+                .timeout_sec
+                .map(|sec| format!("{sec}s"))
+                .unwrap_or_else(|| "none".to_string());
+            let retry = task.retry.unwrap_or(0);
+            println!(
+                "[{}/{}] {}: host={} script={} working_dir={} sudo={} timeout={} retry={} env_keys={}",
+                idx + 1,
+                tasks.len(),
+                task.name,
+                task.host,
+                task.script_path,
+                task.working_dir,
+                task.sudo,
+                timeout,
+                retry,
+                format_env_keys(task)
+            );
         }
+        return Ok(());
+    }
 
+    let ssh_config = read_ssh_config(SshConfigPath::default())?;
+
+    let mut session_manager = SessionManager::new();
+    let client = KuoriClient::new(ssh_config);
+
+    for task in tasks {
         let script_path = Path::new(&task.script_path);
         let working_dir = Path::new(&task.working_dir);
+        let max_attempts = task.retry.unwrap_or(0) + 1;
 
-        client.exec_script(
-            &mut session_manager,
-            &task.host,
-            script_path,
-            working_dir,
-            &task.environments,
-            task.sudo,
-        )?;
+        for attempt in 1..=max_attempts {
+            let result = client.exec_script(
+                &mut session_manager,
+                &task.host,
+                script_path,
+                working_dir,
+                &task.environments,
+                task.sudo,
+                task.timeout_sec,
+            );
+
+            match result {
+                Ok(()) => break,
+                Err(error) if attempt < max_attempts => {
+                    eprintln!(
+                        "task `{}` failed (attempt {}/{}): {}",
+                        task.name, attempt, max_attempts, error
+                    );
+                }
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!(
+                            "task `{}` failed after {} attempt(s)",
+                            task.name, max_attempts
+                        )
+                    });
+                }
+            }
+        }
     }
 
     Ok(())
@@ -194,7 +260,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(CliCommand::Run(run_args)) => {
             let config = load_config(&run_args.config)?;
-            run_tasks(config, run_args.task_names).await?;
+            run_tasks(config, run_args.task_names, run_args.dry_run).await?;
         }
         None => {
             let config_path = args
@@ -202,7 +268,7 @@ async fn main() -> anyhow::Result<()> {
                 .as_ref()
                 .context("`--config` is required (or use `kuori run|validate --config ...`)")?;
             let config = load_config(config_path)?;
-            run_tasks(config, args.task_names).await?;
+            run_tasks(config, args.task_names, args.dry_run).await?;
         }
     }
 

--- a/src/ssh.rs
+++ b/src/ssh.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Ok};
+use anyhow::anyhow;
 use ssh2::Session;
 use ssh2_config::SshConfig;
 use std::{
@@ -7,6 +7,8 @@ use std::{
     io::{self, Read, Write},
     net::TcpStream,
     path::Path,
+    thread,
+    time::{Duration, Instant},
 };
 
 use crate::util::generate_random_string;
@@ -84,6 +86,7 @@ impl KuoriClient {
         remote_script_dir: &Path,
         environments: &HashMap<String, String>,
         use_sudo: bool,
+        timeout_sec: Option<u64>,
     ) -> anyhow::Result<()> {
         let env_command: String = environments
             .iter()
@@ -111,10 +114,10 @@ impl KuoriClient {
         );
 
         // リモートでスクリプトを実行
-        let result = self.run_remote_command(session, command);
+        let result = self.run_remote_command(session, command, timeout_sec);
 
         // スクリプトを削除
-        self.run_remote_command(session, format!("rm {}", remote_script_path))?;
+        self.run_remote_command(session, format!("rm {}", remote_script_path), None)?;
 
         result
     }
@@ -139,20 +142,81 @@ impl KuoriClient {
     }
 
     // リモートでコマンドを実行して結果を返す
-    fn run_remote_command(&self, session: &Session, command: String) -> anyhow::Result<()> {
+    fn run_remote_command(
+        &self,
+        session: &Session,
+        command: String,
+        timeout_sec: Option<u64>,
+    ) -> anyhow::Result<()> {
         let mut channel = session.channel_session()?;
         channel.exec(&command)?;
 
-        let mut buffer = [0; 4096]; // 一度に読み取るバッファサイズを指定
+        let timeout = timeout_sec.map(Duration::from_secs);
+        let started_at = Instant::now();
+
+        session.set_blocking(false);
+        let mut stdout_eof = false;
+        let mut stderr_eof = false;
+        let mut stdout_buffer = [0; 4096];
+        let mut stderr_buffer = [0; 4096];
+
         loop {
-            let n = channel.read(&mut buffer)?;
-            if n == 0 {
-                break; // 読み込みが終了したらループを抜ける
+            let mut has_output = false;
+
+            if !stdout_eof {
+                match channel.read(&mut stdout_buffer) {
+                    Ok(0) => stdout_eof = true,
+                    Ok(n) => {
+                        io::stdout().write_all(&stdout_buffer[..n])?;
+                        io::stdout().flush()?;
+                        has_output = true;
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+                    Err(error) => {
+                        session.set_blocking(true);
+                        return Err(error.into());
+                    }
+                }
             }
-            io::stdout().write_all(&buffer[..n])?; // 取得したデータを即座に標準出力に表示
-            io::stdout().flush()?; // バッファをフラッシュしてリアルタイムで表示
+
+            if !stderr_eof {
+                match channel.stderr().read(&mut stderr_buffer) {
+                    Ok(0) => stderr_eof = true,
+                    Ok(n) => {
+                        io::stderr().write_all(&stderr_buffer[..n])?;
+                        io::stderr().flush()?;
+                        has_output = true;
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+                    Err(error) => {
+                        session.set_blocking(true);
+                        return Err(error.into());
+                    }
+                }
+            }
+
+            if channel.eof() && stdout_eof && stderr_eof {
+                break;
+            }
+
+            if let Some(limit) = timeout {
+                if started_at.elapsed() > limit {
+                    let _ = channel.close();
+                    session.set_blocking(true);
+                    anyhow::bail!(
+                        "コマンド実行がタイムアウトしました ({}秒): {}",
+                        limit.as_secs(),
+                        command
+                    );
+                }
+            }
+
+            if !has_output {
+                thread::sleep(Duration::from_millis(50));
+            }
         }
 
+        session.set_blocking(true);
         channel.wait_close()?;
         let exit_status = channel.exit_status()?;
         if exit_status != 0 {


### PR DESCRIPTION
## 背景 / 目的
`kuori` 実行前にタスク計画を確認したい、また長時間ハング時に自動で失敗させたい、失敗時に一定回数リトライしたいという運用ニーズに対応するため。

## 変更内容
- CLI に `--dry-run` を追加
  - `kuori run --config ... --dry-run`
  - 後方互換の `kuori --config ... --dry-run` でも動作
- タスク設定に `timeout_sec` / `retry` を追加
  - `timeout_sec`: 1 回の実行で許可する最大秒数（未指定は無制限）
  - `retry`: 失敗時の再試行回数（`0` は再試行なし）
- `timeout_sec` のバリデーション追加（`0` は不正）
- README / config.example.json を更新

## 動作確認
- `cargo fmt --all`
- `cargo test`（9件成功）
- `cargo run -- run --config config.example.json --dry-run` で実行予定の表示を確認
- `cargo run -- --config config.example.json --dry-run`（後方互換経路）を確認

## 影響範囲 / リスク / ロールバック
- 影響範囲: 実行CLI、設定スキーマ、SSH実行処理、README
- 後方互換: 既存設定は `timeout_sec` / `retry` 未指定で従来どおり動作
- リスク: リトライ時はスクリプトが再実行されるため、非冪等処理は設定時に注意
- ロールバック: 当該コミットのrevertで戻せます
